### PR TITLE
Add Configuration.apiKey + fix coinLatestOhlcv quote typo + re-enable paid tests

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -4,12 +4,26 @@ on: [push, pull_request]
 
 jobs:
   build:
-
     runs-on: macOS-latest
-
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v4
     - name: Build
       run: swift build -v
     - name: Run tests
       run: swift test -v
+
+  integration-paid:
+    runs-on: macOS-latest
+    needs: build
+    if: github.event_name == 'push' && github.repository == 'coinpaprika/coinpaprika-api-swift-client'
+    steps:
+    - uses: actions/checkout@v4
+    - name: Run tests with paid-tier API key
+      env:
+        COINPAPRIKA_API_KEY: ${{ secrets.COINPAPRIKA_API_KEY }}
+      run: |
+        if [ -z "$COINPAPRIKA_API_KEY" ]; then
+          echo "COINPAPRIKA_API_KEY secret not configured; skipping paid-tier tests."
+          exit 0
+        fi
+        swift test -v

--- a/Sources/Client/API.swift
+++ b/Sources/Client/API.swift
@@ -327,7 +327,7 @@ public struct API {
     /// - Returns: Request to perform
     public static func coinLatestOhlcv(id: String, quote: QuoteCurrency = .usd) -> Request<[Ohlcv]> {
         validateCoinOhlcvQuote(quote)
-        return request(method: .get, path: "coins/\(id)/ohlcv/latest", params: ["query": quote.rawValue])
+        return request(method: .get, path: "coins/\(id)/ohlcv/latest", params: ["quote": quote.rawValue])
     }
 
     /// Historical Open/High/Low/Close values with volume and market_cap

--- a/Sources/Client/API.swift
+++ b/Sources/Client/API.swift
@@ -434,7 +434,8 @@ public struct API {
     }
     
     private static func request<Model: Decodable>(method: Request<Model>.Method, path: String, params: Request<Model>.Params?) -> Request<Model> {
-        return Request<Model>(baseUrl: Configuration.baseUrl, method: method, path: path, params: params, userAgent: Configuration.userAgent)
+        let auth: Request<Model>.AuthorisationMethod = Configuration.apiKey.map { .bearer(token: $0) } ?? .none
+        return Request<Model>(baseUrl: Configuration.baseUrl, method: method, path: path, params: params, userAgent: Configuration.userAgent, authorisation: auth)
     }
        
     private static func compact(_ optional: [String: Any?]) -> [String: Any] {

--- a/Sources/Client/API.swift
+++ b/Sources/Client/API.swift
@@ -327,7 +327,10 @@ public struct API {
     /// - Returns: Request to perform
     public static func coinLatestOhlcv(id: String, quote: QuoteCurrency = .usd) -> Request<[Ohlcv]> {
         validateCoinOhlcvQuote(quote)
-        return request(method: .get, path: "coins/\(id)/ohlcv/latest", params: ["quote": quote.rawValue])
+        // /coins/{id}/ohlcv/latest is case-sensitive on `quote`: uppercase
+        // returns 400 invalid parameters. Other endpoints (`tickers?quotes=`,
+        // `ohlcv/historical?quote=`) accept both cases.
+        return request(method: .get, path: "coins/\(id)/ohlcv/latest", params: ["quote": quote.rawValue.lowercased()])
     }
 
     /// Historical Open/High/Low/Close values with volume and market_cap

--- a/Sources/Client/Configuration.swift
+++ b/Sources/Client/Configuration.swift
@@ -12,4 +12,14 @@ public typealias CoinpaprikaConfiguration = Configuration
 public struct Configuration {
     public static var baseUrl = URL(string: "https://api.coinpaprika.com/v1/")!
     public static var userAgent = "Coinpaprika API Client - Swift"
+
+    /// API key used to authenticate requests against api-pro.coinpaprika.com.
+    /// When non-nil, every static `Coinpaprika.API.*` call sends the key on
+    /// the `Authorization` header. Default is nil (free tier, no auth).
+    ///
+    /// Paid plans require both `apiKey` and `baseUrl` set:
+    ///
+    ///     Configuration.apiKey = "your-api-key"
+    ///     Configuration.baseUrl = URL(string: "https://api-pro.coinpaprika.com/v1/")!
+    public static var apiKey: String?
 }

--- a/Tests/RequestTests.swift
+++ b/Tests/RequestTests.swift
@@ -14,40 +14,29 @@ import CoinpaprikaNetworkingMocks
 class RequestTests: XCTestCase {
 
     let bitcoinId = "btc-bitcoin"
-    let satoshiId = "satoshi-nakamoto"
+    let personId = "charlie-lee"
     let binanceId = "binance"
 
-    // MARK: - Skip helpers
-    //
-    // A subset of these tests hit live endpoints that are gated to paid plans
-    // (`/tickers/{id}/historical`, `/coins/{id}/ohlcv/historical`). The Swift
-    // SDK currently has no public mechanism for injecting an API key into the
-    // static `Coinpaprika.API.*` calls — `Configuration` has no `apiKey` field
-    // and the static methods build `Request` instances with `.none` auth by
-    // default. Setting `COINPAPRIKA_API_KEY` in the test environment alone is
-    // therefore not enough to make these tests pass.
-    //
-    // To re-enable the paid-tier tests:
-    //   1. Add `Configuration.apiKey: String?`.
-    //   2. Update each affected static method in `API.swift` to construct
-    //      `Request` with
-    //        `authorisation: Configuration.apiKey.map { .bearer(token: $0) } ?? .none`.
-    //   3. Provide a paid key in the `COINPAPRIKA_API_KEY` environment variable.
-    //   4. Remove the `try skipPaidEndpointTest()` call from each affected test.
-    //
-    // Tracked in the DevRel cleanup audit as a follow-up to the Bearer fix.
+    private let freeTierBaseUrl = URL(string: "https://api.coinpaprika.com/v1/")!
+    private let paidTierBaseUrl = URL(string: "https://api-pro.coinpaprika.com/v1/")!
 
-    /// Skip a test that hits a paid-tier endpoint pending SDK auth wiring.
-    private func skipPaidEndpointTest() throws {
-        try XCTSkipIf(
-            true,
-            "Paid-tier endpoint; SDK auth wiring required. See class-level comment for re-enable steps."
-        )
+    override func tearDown() {
+        Configuration.apiKey = nil
+        Configuration.baseUrl = freeTierBaseUrl
+        super.tearDown()
     }
 
-    /// Skip a test whose live fixture id is no longer valid.
-    private func skipStaleFixture(_ details: String) throws {
-        try XCTSkipIf(true, "Stale test fixture: \(details)")
+    /// Skip the test if `COINPAPRIKA_API_KEY` is not set, otherwise configure
+    /// the SDK for paid-tier requests for the duration of the test. Paid-tier
+    /// state is reset in `tearDown`.
+    private func configurePaidTier() throws {
+        let key = ProcessInfo.processInfo.environment["COINPAPRIKA_API_KEY"]
+        try XCTSkipIf(
+            key == nil,
+            "Paid-tier endpoint requires COINPAPRIKA_API_KEY env var. Skipping."
+        )
+        Configuration.apiKey = key
+        Configuration.baseUrl = paidTierBaseUrl
     }
 
     func testGlobalStatsRequest() {
@@ -286,7 +275,7 @@ class RequestTests: XCTestCase {
     }
     
     func testTickerHistoryRequest() throws {
-        try skipPaidEndpointTest()
+        try configurePaidTier()
 
         let expectation = self.expectation(description: "Waiting for ticker history")
         let limit = 5
@@ -376,18 +365,12 @@ class RequestTests: XCTestCase {
         waitForExpectations(timeout: 30)
     }
     
-    func testPersonRequest() throws {
-        try skipStaleFixture(
-            "person id 'satoshi-nakamoto' returns HTTP 404 from /people/{id} as of 2026-04-29 (verified in DevRel audit). Update fixture id to a person currently in the database before re-enabling."
-        )
-
+    func testPersonRequest() {
         let expectation = self.expectation(description: "Waiting for person details")
 
-        Coinpaprika.API.person(id: satoshiId).perform { (response) in
+        Coinpaprika.API.person(id: personId).perform { (response) in
             let person = response.value
             XCTAssertNotNil(person, "Person should exist")
-
-
             expectation.fulfill()
         }
 
@@ -434,7 +417,7 @@ class RequestTests: XCTestCase {
     }
     
     func testCoinHistoricalOhlcvRequest() throws {
-        try skipPaidEndpointTest()
+        try configurePaidTier()
 
         let expectation = self.expectation(description: "Waiting for a latest ohlcv")
 
@@ -538,7 +521,87 @@ class RequestTests: XCTestCase {
             }
             expectation.fulfill()
         }
-        
+
         waitForExpectations(timeout: 30)
+    }
+
+    func testApiKeyInjectionWhenSet() {
+        Configuration.apiKey = "test-key-abc123"
+
+        let capture = RequestCapturingSession(stubResponse: "{}")
+        let expectation = self.expectation(description: "Waiting for request to be captured")
+
+        Coinpaprika.API.global().perform(session: capture) { _ in
+            expectation.fulfill()
+        }
+
+        waitForExpectations(timeout: 5)
+
+        XCTAssertEqual(
+            capture.capturedRequest?.value(forHTTPHeaderField: "Authorization"),
+            "test-key-abc123",
+            "Authorization header should carry the bare API key when Configuration.apiKey is set"
+        )
+    }
+
+    func testNoAuthorizationHeaderWhenApiKeyNil() {
+        Configuration.apiKey = nil
+
+        let capture = RequestCapturingSession(stubResponse: "{}")
+        let expectation = self.expectation(description: "Waiting for request to be captured")
+
+        Coinpaprika.API.global().perform(session: capture) { _ in
+            expectation.fulfill()
+        }
+
+        waitForExpectations(timeout: 5)
+
+        XCTAssertNil(
+            capture.capturedRequest?.value(forHTTPHeaderField: "Authorization"),
+            "Authorization header should be absent when Configuration.apiKey is nil"
+        )
+    }
+
+    func testCoinLatestOhlcvSendsQuoteParam() {
+        let capture = RequestCapturingSession(stubResponse: "[]")
+        let expectation = self.expectation(description: "Waiting for request to be captured")
+
+        Coinpaprika.API.coinLatestOhlcv(id: bitcoinId, quote: .btc).perform(session: capture) { _ in
+            expectation.fulfill()
+        }
+
+        waitForExpectations(timeout: 5)
+
+        let url = capture.capturedRequest?.url?.absoluteString ?? ""
+        XCTAssertTrue(
+            url.contains("quote=btc"),
+            "URL should contain quote=btc, got: \(url)"
+        )
+        XCTAssertFalse(
+            url.contains("query="),
+            "URL should not contain the legacy 'query=' typo, got: \(url)"
+        )
+    }
+}
+
+/// Captures the outgoing URLRequest for header/query-string assertions
+/// while returning a canned response body.
+private final class RequestCapturingSession: NetworkSession {
+    private(set) var capturedRequest: URLRequest?
+    private let stubResponse: Data
+
+    init(stubResponse: String) {
+        self.stubResponse = stubResponse.data(using: .utf8) ?? Data()
+    }
+
+    func loadData(with request: URLRequest, completionHandler: @escaping (Data?, URLResponse?, Error?) -> Void) {
+        capturedRequest = request
+        let response = HTTPURLResponse(
+            url: request.url!,
+            statusCode: 200,
+            httpVersion: "HTTP/1.1",
+            headerFields: ["Content-Type": "application/json"]
+        )
+        completionHandler(stubResponse, response, nil)
     }
 }

--- a/Tests/RequestTests.swift
+++ b/Tests/RequestTests.swift
@@ -528,10 +528,10 @@ class RequestTests: XCTestCase {
     func testApiKeyInjectionWhenSet() {
         Configuration.apiKey = "test-key-abc123"
 
-        let capture = RequestCapturingSession(stubResponse: "{}")
+        let capture = RequestCapturingSession(stubResponse: "[]")
         let expectation = self.expectation(description: "Waiting for request to be captured")
 
-        Coinpaprika.API.global().perform(session: capture) { _ in
+        Coinpaprika.API.fiats().perform(session: capture) { _ in
             expectation.fulfill()
         }
 
@@ -547,10 +547,10 @@ class RequestTests: XCTestCase {
     func testNoAuthorizationHeaderWhenApiKeyNil() {
         Configuration.apiKey = nil
 
-        let capture = RequestCapturingSession(stubResponse: "{}")
+        let capture = RequestCapturingSession(stubResponse: "[]")
         let expectation = self.expectation(description: "Waiting for request to be captured")
 
-        Coinpaprika.API.global().perform(session: capture) { _ in
+        Coinpaprika.API.fiats().perform(session: capture) { _ in
             expectation.fulfill()
         }
 


### PR DESCRIPTION
## Stacked on top of #16

This PR is built on the `fix/bearer-auth-bare-key` branch from #16. The diff below currently includes #16's changes. Once #16 lands on master, I rebase this branch and the diff shrinks to just the work below.

**Recommended review order:** review/merge #16 first, then this one.

## What this changes

Three things, in three logical commits, plus a CI commit.

### 1. Auth injection (`Configuration.apiKey`)

Adds `Configuration.apiKey: String?`. When non-nil, every static `Coinpaprika.API.*` call sends the bare key on the `Authorization` header (#16 makes the bare-token routing actually work). When nil, behaviour is unchanged.

```swift
Configuration.apiKey = "your-api-key"
Configuration.baseUrl = URL(string: "https://api-pro.coinpaprika.com/v1/")!
```

Pure additive surface change. No existing caller sees a difference.

### 2. Fix `coinLatestOhlcv` quote typo

Same shape of bug as the `Authorisation` header: the SDK has been sending the wrong key name. The OpenAPI parameter is `quote`, the Swift method has been sending `query` since 2019. Server silently ignores the unknown key and falls back to USD.

Verified live 2026-05-07:

```
/coins/btc-bitcoin/ohlcv/latest?quote=btc -> [{"open": 1, "high": 1.016, ...}]   (BTC priced in BTC, correct)
/coins/btc-bitcoin/ohlcv/latest?query=btc -> [{"open": 80919.86, ...}]            (USD, the broken default)
```

⚠️ **Behaviour change** for any caller passing `quote: .btc` and expecting USD-default broken behaviour. The public method signature is unchanged — only what hits the wire changes. Worth flagging to consumers in the next release notes.

### 3. Re-enable paid-tier tests

Removes the `skipPaidEndpointTest()` / `skipStaleFixture()` workaround helpers from #16. The two paid-tier tests (`testTickerHistoryRequest`, `testCoinHistoricalOhlcvRequest`) now gate on `COINPAPRIKA_API_KEY` env var: present means run, absent means `XCTSkip`. Configuration mutations are reset in `tearDown` so paid-tier state doesn't leak between tests.

Also fixes the stale `testPersonRequest` fixture: `satoshi-nakamoto` started returning 404 some time before the 2026-04 audit. Switched to `charlie-lee` (verified 200 live on 2026-05-07).

Three new tests using a `RequestCapturingSession` to assert on outgoing headers/URLs:

- `testApiKeyInjectionWhenSet` — Authorization header carries the bare key
- `testNoAuthorizationHeaderWhenApiKeyNil` — header absent on free tier
- `testCoinLatestOhlcvSendsQuoteParam` — `quote=` present, `query=` absent

### 4. CI

- `actions/checkout@v1` -> `@v4` (v1 was Node 12, EOL'd years ago)
- New `integration-paid` job runs `swift test` with `COINPAPRIKA_API_KEY` from a repo secret. Gated to push events on the canonical repo (no fork PRs, no leaking secrets). If the secret isn't configured, the job exits 0 with a notice.

## What this does NOT change

Per the backwards-compatibility rule, no deprecations and no renames in this PR:

- `AuthorisationMethod` typo not renamed
- `.bearer(token:)` not renamed to `.apiKey(_:)`
- `latestNews` / `historicalNews` / `topMovers` / `fiats` / `personTweets` / `createEvent` not annotated `@available(*, deprecated)`. Five of the six still respond 200 on the live server. Removing them stays as v3.0 work.

## Validation

- `swift build` passes locally (Swift 6.3, no Xcode.app available so test target requires CI for full validation)
- All three `quote=` / Authorization assertions verified live with curl (results in commit messages and above)
- `charlie-lee` person endpoint verified 200 live

## Action item for repo settings

For the new `integration-paid` CI job to actually run paid-tier tests, configure `COINPAPRIKA_API_KEY` in:

  Settings -> Secrets and variables -> Actions -> New repository secret

Until that's set, the job is a no-op (exits 0 with a notice).