### PR TITLE
Fix validate*Limit asserts that compared min>=min and max<=max

### DIFF
--- a/Sources/Client/API.swift
+++ b/Sources/Client/API.swift
@@ -235,7 +235,7 @@ public struct API {
     private static func validateTickerHistoryLimit(_ limit: Int) {
         let min = 1
         let max = 5000
-        assert(min >= min && max <= max, "Limit should be between \(min) and \(max).")
+        assert(limit >= min && limit <= max, "Limit should be between \(min) and \(max).")
     }
     
     /// Intervals for historical data endpoint
@@ -317,7 +317,7 @@ public struct API {
     private static func validateCoinOhlcvLimit(_ limit: Int) {
         let min = 1
         let max = 366
-        assert(min >= min && max <= max, "Limit should be between \(min) and \(max).")
+        assert(limit >= min && limit <= max, "Limit should be between \(min) and \(max).")
     }
     
     /// Latest Open/High/Low/Close values with volume and market_cap


### PR DESCRIPTION
## What

Two private validation helpers in `API.swift` had tautological asserts:

```swift
private static func validateTickerHistoryLimit(_ limit: Int) {
    let min = 1
    let max = 5000
    assert(min >= min && max <= max, "Limit should be between \(min) and \(max).")
}
```

`min >= min` and `max <= max` are both always true — the assert never fires regardless of the `limit` value. Same shape in `validateCoinOhlcvLimit`. Net effect: callers can pass any integer (negative, zero, 100000) and the SDK forwards it to the server, which then returns a generic 4xx that's harder to debug than a local assert.

## Fix

Compare `limit` against the bounds, not the bounds against themselves:

```swift
assert(limit >= min && limit <= max, "Limit should be between \(min) and \(max).")
```

Two-line change. DEBUG-only behaviour change (asserts are no-ops in release), so production behaviour is unchanged.

## Why a separate PR

Pre-existing bug, unrelated to the missing-endpoints + auth-injection work in #17 / #18. Different concern, trivial diff, easy to revert if it surfaces something unexpected.