### PR TITLE
Fix E2E findings: CocoaPods compile, Exchange null description, HTTP 402 mapping

### DIFF
--- a/Sources/Client/Models/ChangelogEntry.swift
+++ b/Sources/Client/Models/ChangelogEntry.swift
@@ -6,6 +6,7 @@
 import Foundation
 #if canImport(CoinpaprikaNetworking)
 import CoinpaprikaNetworking
+#endif
 
 /// A single coin id change recorded in the Coinpaprika changelog
 /// (returned by `/changelog/ids`, paid plans).
@@ -30,4 +31,3 @@ public struct ChangelogEntry: Equatable, CodableModel {
         case changedAt = "changed_at"
     }
 }
-#endif

--- a/Sources/Client/Models/CoinMapping.swift
+++ b/Sources/Client/Models/CoinMapping.swift
@@ -6,6 +6,7 @@
 import Foundation
 #if canImport(CoinpaprikaNetworking)
 import CoinpaprikaNetworking
+#endif
 
 /// ID mapping between Coinpaprika and other providers (returned by `/coins/mappings`, paid plans).
 ///
@@ -62,4 +63,3 @@ public struct CoinMapping: Equatable, CodableModel {
         return nil
     }
 }
-#endif

--- a/Sources/Client/Models/Contract.swift
+++ b/Sources/Client/Models/Contract.swift
@@ -6,6 +6,7 @@
 import Foundation
 #if canImport(CoinpaprikaNetworking)
 import CoinpaprikaNetworking
+#endif
 
 /// Smart-contract address mapped to a coin id (returned by `/contracts/{platform_id}`).
 public struct Contract: Equatable, CodableModel {
@@ -29,4 +30,3 @@ public struct Contract: Equatable, CodableModel {
         case active
     }
 }
-#endif

--- a/Sources/Client/Models/Exchange.swift
+++ b/Sources/Client/Models/Exchange.swift
@@ -18,8 +18,10 @@ public struct Exchange: Equatable, CodableModel {
     /// Exchange name, eg. Binance
     public let name: String
     
-    /// Exchange description
-    public let description: String
+    /// Exchange description. Optional because the API returns `null` for
+    /// exchanges that don't have one yet (verified 2026-05-11: 61 of 1109
+    /// exchanges return null).
+    public let description: String?
     
     /// Is this exchange active
     public let active: Bool

--- a/Sources/Client/Models/KeyInfo.swift
+++ b/Sources/Client/Models/KeyInfo.swift
@@ -6,6 +6,7 @@
 import Foundation
 #if canImport(CoinpaprikaNetworking)
 import CoinpaprikaNetworking
+#endif
 
 /// API key information returned by `/key/info` (paid plans).
 public struct KeyInfo: Equatable, CodableModel {
@@ -61,4 +62,3 @@ public struct KeyInfo: Equatable, CodableModel {
         case usage
     }
 }
-#endif

--- a/Sources/Client/Models/PriceConversion.swift
+++ b/Sources/Client/Models/PriceConversion.swift
@@ -6,6 +6,7 @@
 import Foundation
 #if canImport(CoinpaprikaNetworking)
 import CoinpaprikaNetworking
+#endif
 
 /// Result of converting an amount from one currency to another (returned by `/price-converter`).
 public struct PriceConversion: Equatable, CodableModel {
@@ -45,4 +46,3 @@ public struct PriceConversion: Equatable, CodableModel {
         case price
     }
 }
-#endif

--- a/Sources/Networking/Errors.swift
+++ b/Sources/Networking/Errors.swift
@@ -27,14 +27,20 @@ public enum ResponseError: Error {
     case emptyResponse(url: URL?)
     case unableToDecodeResponse(url: URL?)
     case requestsLimitExceeded(url: URL?)
+    /// Returned when the API responds with HTTP 402 — monthly request quota
+    /// for the API key has been exhausted. Operationally distinct from
+    /// `.requestsLimitExceeded` (HTTP 429, short-window rate limit) and from
+    /// `.invalidRequest` (HTTP 4xx for genuine client errors).
+    case quotaExceeded(url: URL?)
     case invalidRequest(httpCode: Int, url: URL?, message: String?)
     case serverError(httpCode: Int, url: URL?)
-    
+
     public var url: URL? {
         switch self {
         case .emptyResponse(let url),
             .unableToDecodeResponse(let url),
             .requestsLimitExceeded(let url),
+            .quotaExceeded(let url),
             .invalidRequest(_, let url, _),
             .serverError(_, let url):
             return url
@@ -51,6 +57,8 @@ extension ResponseError: LocalizedError {
             return "Unable to decode response"
         case .requestsLimitExceeded:
             return "Requests limit exceeded"
+        case .quotaExceeded:
+            return "API key monthly quota exceeded"
         case .invalidRequest(let httpCode, _, let message):
             guard let message = message else {
                 return "Invalid request [\(httpCode)]"

--- a/Sources/Networking/Request.swift
+++ b/Sources/Networking/Request.swift
@@ -216,6 +216,8 @@ public struct Request<Model: Decodable>: Requestable {
     public static func defaultErrorParser() -> ErrorParser {
         return { (response, data) in
             switch response.statusCode {
+              case 402:
+                  return ResponseError.quotaExceeded(url: response.url)
               case 429:
                   return ResponseError.requestsLimitExceeded(url: response.url)
               case 400 ..< 500:

--- a/Tests/RequestTests.swift
+++ b/Tests/RequestTests.swift
@@ -1134,6 +1134,44 @@ class RequestTests: XCTestCase {
         let url = capture.capturedRequest?.url?.absoluteString ?? ""
         XCTAssertFalse(url.contains("page="), "URL should not contain page when nil, got: \(url)")
     }
+
+    // MARK: - Exchange.description optional regression guard
+
+    func testExchangeDecodesWithNullDescription() {
+        // Real api.coinpaprika.com behaviour as of 2026-05-11: 61 of 1109
+        // exchanges return null for description. Exchange.description must
+        // be optional so the array decode does not fail on any single
+        // null-description entry.
+        let json = """
+        {
+          "id": "test-exchange",
+          "name": "Test Exchange",
+          "description": null,
+          "active": true,
+          "website_status": true,
+          "api_status": true,
+          "message": null,
+          "links": null,
+          "markets_data_fetched": false,
+          "adjusted_rank": null,
+          "reported_rank": null,
+          "currencies": 0,
+          "markets": 0,
+          "fiats": [],
+          "last_updated": "2026-05-11T12:00:00Z",
+          "quotes": {}
+        }
+        """
+        let expectation = self.expectation(description: "Waiting for exchange decode")
+        Coinpaprika.API.exchange(id: "test-exchange").perform(session: JsonMock(json)) { (response) in
+            let exchange = response.value
+            XCTAssertNotNil(exchange, "Exchange with null description should decode")
+            XCTAssertNil(exchange?.description, "null description should decode to nil")
+            XCTAssertEqual(exchange?.id, "test-exchange")
+            expectation.fulfill()
+        }
+        waitForExpectations(timeout: 5)
+    }
 }
 
 /// Captures the outgoing URLRequest for header/query-string assertions

--- a/Tests/RequestTests.swift
+++ b/Tests/RequestTests.swift
@@ -1135,6 +1135,21 @@ class RequestTests: XCTestCase {
         XCTAssertFalse(url.contains("page="), "URL should not contain page when nil, got: \(url)")
     }
 
+    // MARK: - Quota-exceeded error mapping
+
+    func testQuotaExceededOn402() {
+        let expectation = self.expectation(description: "Waiting for API")
+        Coinpaprika.API.global().perform(session: JsonMock("{}", statusCode: 402)) { (response) in
+            if let responseError = response.error as? ResponseError, case .quotaExceeded(let url) = responseError {
+                XCTAssertNotNil(url)
+            } else {
+                XCTFail("HTTP 402 should map to ResponseError.quotaExceeded, got \(String(describing: response.error))")
+            }
+            expectation.fulfill()
+        }
+        waitForExpectations(timeout: 5)
+    }
+
     // MARK: - Exchange.description optional regression guard
 
     func testExchangeDecodesWithNullDescription() {


### PR DESCRIPTION
Three fixes from the post-merge end-to-end validation report.

## NF1 (blocker) — CocoaPods consumers couldn't compile

PR #18 review feedback moved `#endif` to end of file in 5 new model files so the struct definitions were gated alongside the `import`. That worked for SwiftPM and Carthage where `CoinpaprikaNetworking` is a separate module (`canImport` returns true). It broke CocoaPods consumers where all source files compile into a single module and `canImport` returns false — the type body got gated out, and consumer code failed with "cannot find type KeyInfo / CoinMapping / Contract / ChangelogEntry / PriceConversion".

`pod lib lint --quick` does not catch this — it lints podspec syntax only, not consumer compilation. The E2E agent's `pod install` in a fresh consumer project surfaced it.

Reverts to the same pattern every existing model has used since 2018 (Fiat, Coin, Ticker, Exchange, etc.): gate only the `import`, leave the struct body always visible. `CodableModel` is still available in single-module builds because it lives in the same module.

## NF2 (blocker) — `Exchange.description` decode-fails on live data

`Exchange.description: String` was non-optional. 61 of 1109 exchanges on api.coinpaprika.com currently return `null` for that field (verified 2026-05-11). Any single null entry caused `API.exchanges()` to fail decoding the entire array. The single-exchange endpoint `API.exchange(id:)` had the same failure mode for those ids.

Pre-existing since 2018. Surfaced because CI now exercises the list endpoint live with the enterprise key.

Added a decoder regression test using a null-description fixture to lock the optional declaration.

## NF3 (high) — HTTP 402 mishandled

`defaultErrorParser` handled 429 (rate limit) specifically but lumped 402 (Coinpaprika quota exhaustion) into the generic `invalidRequest` bucket. Callers couldn't distinguish "monthly quota exhausted, upgrade plan" from "this specific request is malformed".

Adds `ResponseError.quotaExceeded(url:)` and maps HTTP 402 to it. Added a test using `JsonMock` with statusCode 402 to lock the mapping.

Pre-existing gap from 2018 — never triggered before because enterprise plans have unlimited quota and prior testing didn't exercise the free tier at quota-exhausting volume.

## What this PR does NOT change

- **NF4** (TSAN data race on `Configuration.apiKey`) — deferred to v3.0 per the round-2 review report. This PR keeps the global-static pattern.
- **NF5–NF10** documentation findings — separate doc-only follow-up.

## Verification

- `swift build` clean
- New unit tests added: `testExchangeDecodesWithNullDescription`, `testQuotaExceededOn402`
- The NF1 fix is verified by running `pod install` in a fresh consumer project against this branch — types resolve, build passes

## Action item

After this lands, cut a `2.5.1` (or `3.0.1` if you bumped to 3.0.0) patch release and re-publish to CocoaPods. The CocoaPods consumer experience was broken on `2.5.0` / `3.0.0`.